### PR TITLE
Centralize Crashlytics logging about session state

### DIFF
--- a/app/src/main/java/io/fabric/samples/cannonball/App.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/App.java
@@ -23,13 +23,13 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 
 import com.crashlytics.android.Crashlytics;
+
+import io.fabric.sdk.android.Fabric;
+
 import com.twitter.sdk.android.Twitter;
 import com.twitter.sdk.android.core.TwitterAuthConfig;
 
 import java.io.File;
-
-import io.fabric.sdk.android.Fabric;
-
 
 /**
  * This class represents the Application and extends Application it is used to initiate the
@@ -103,7 +103,7 @@ public class App extends Application {
             Fabric.with(fabric);
         }
 
-        Crashlytics.setBool(App.CRASHLYTICS_KEY_CRASHES, areCrashesEnabled());
+        Crashlytics.setBool(CRASHLYTICS_KEY_CRASHES, areCrashesEnabled());
     }
 
     private void extractAvenir() {

--- a/app/src/main/java/io/fabric/samples/cannonball/SessionRecorder.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/SessionRecorder.java
@@ -1,0 +1,40 @@
+package io.fabric.samples.cannonball;
+
+import com.crashlytics.android.Crashlytics;
+import com.twitter.sdk.android.core.Session;
+
+public class SessionRecorder {
+    public static Session recordInitialSessionState(Session twitterSession,
+                                                    Session digitsSession) {
+        if (twitterSession != null) {
+            recordSessionActive("Splash: user with active Twitter session", twitterSession);
+            return twitterSession;
+        } else if (digitsSession != null) {
+            recordSessionActive("Splash: user with active Digits session", digitsSession);
+            return digitsSession;
+        } else {
+            recordSessionInactive("Splash: anonymous user");
+            return null;
+        }
+    }
+
+    public static void recordSessionActive(String message, Session session) {
+        recordSessionActive(message, String.valueOf(session.getId()));
+    }
+
+    public static void recordSessionInactive(String message) {
+        recordSessionState(message, null, false);
+    }
+
+    private static void recordSessionActive(String message, String userIdentifier) {
+        recordSessionState(message, userIdentifier, true);
+    }
+
+    private static void recordSessionState(String message,
+                                           String userIdentifier,
+                                           boolean active) {
+        Crashlytics.log(message);
+        Crashlytics.setUserIdentifier(userIdentifier);
+        Crashlytics.setBool(App.CRASHLYTICS_KEY_SESSION_ACTIVATED, active);
+    }
+}

--- a/app/src/main/java/io/fabric/samples/cannonball/activity/AboutActivity.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/activity/AboutActivity.java
@@ -29,6 +29,7 @@ import com.twitter.sdk.android.Twitter;
 
 import io.fabric.samples.cannonball.App;
 import io.fabric.samples.cannonball.R;
+import io.fabric.samples.cannonball.SessionRecorder;
 
 public class AboutActivity extends Activity {
 
@@ -49,9 +50,9 @@ public class AboutActivity extends Activity {
         bt.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Crashlytics.log("About: deactivating accounts");
                 Twitter.getSessionManager().clearActiveSession();
                 Digits.getSessionManager().clearActiveSession();
+                SessionRecorder.recordSessionInactive("About: accounts deactivated");
 
                 Toast.makeText(getApplicationContext(), "All accounts are cleared",
                         Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/io/fabric/samples/cannonball/activity/InitialActivity.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/activity/InitialActivity.java
@@ -20,41 +20,38 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import com.crashlytics.android.Crashlytics;
 import com.twitter.sdk.android.Twitter;
-import com.twitter.sdk.android.core.TwitterSession;
 
-import io.fabric.samples.cannonball.App;
+import com.digits.sdk.android.Digits;
+
+import io.fabric.samples.cannonball.SessionRecorder;
+
+import com.twitter.sdk.android.core.Session;
+
 
 public class InitialActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final TwitterSession session = Twitter.getSessionManager().getActiveSession();
-        if (session != null) {
-            startThemeActivity(session);
+
+        final Session activeSession = SessionRecorder.recordInitialSessionState(
+                Twitter.getSessionManager().getActiveSession(),
+                Digits.getSessionManager().getActiveSession()
+        );
+
+        if (activeSession != null) {
+            startThemeActivity();
         } else {
             startLoginActivity();
         }
     }
 
-    private void startThemeActivity(TwitterSession session) {
-        final Intent intent = new Intent(this, ThemeChooserActivity.class);
-        startActivity(intent);
-        log("Splash: user with active session", true);
-        Crashlytics.setUserName(session.getUserName());
-        Crashlytics.setUserIdentifier(String.valueOf(session.getUserId()));
+    private void startThemeActivity() {
+        startActivity(new Intent(this, ThemeChooserActivity.class));
     }
 
     private void startLoginActivity() {
-        final Intent intent = new Intent(this, LoginActivity.class);
-        startActivity(intent);
-        log("Splash: anonymous user", false);
-    }
-
-    private void log(String log, boolean state) {
-        Crashlytics.log(log);
-        Crashlytics.setBool(App.CRASHLYTICS_KEY_SESSION_ACTIVATED, state);
+        startActivity(new Intent(this, LoginActivity.class));
     }
 }

--- a/app/src/main/java/io/fabric/samples/cannonball/activity/LoginActivity.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/activity/LoginActivity.java
@@ -34,8 +34,8 @@ import com.twitter.sdk.android.core.TwitterException;
 import com.twitter.sdk.android.core.TwitterSession;
 import com.twitter.sdk.android.core.identity.TwitterLoginButton;
 
-import io.fabric.samples.cannonball.App;
 import io.fabric.samples.cannonball.R;
+import io.fabric.samples.cannonball.SessionRecorder;
 
 public class LoginActivity extends Activity {
 
@@ -60,9 +60,7 @@ public class LoginActivity extends Activity {
         twitterButton.setCallback(new Callback<TwitterSession>() {
             @Override
             public void success(Result<TwitterSession> result) {
-                Crashlytics.log("Login: twitter account activated");
-                Crashlytics.setUserIdentifier(String.valueOf(result.data.getUserId()));
-                Crashlytics.setBool(App.CRASHLYTICS_KEY_SESSION_ACTIVATED, true);
+                SessionRecorder.recordSessionActive("Login: twitter account active", result.data);
                 startThemeChooser();
             }
 
@@ -81,8 +79,7 @@ public class LoginActivity extends Activity {
         phoneButton.setCallback(new AuthCallback() {
             @Override
             public void success(DigitsSession digitsSession, String phoneNumber) {
-                Crashlytics.log("Login: digits session activated");
-                Crashlytics.setUserIdentifier(String.valueOf(digitsSession.getId()));
+                SessionRecorder.recordSessionActive("Login: digits account active", digitsSession);
                 startThemeChooser();
             }
 


### PR DESCRIPTION
- Include an active DigitsSession in the checks to capture active session state at start-up time.
- Centralize Crashlytics session capture calls in App for clarity and code reuse.
