### PR TITLE
Add theming to Digits

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url "https://maven.fabric.io/repo" }
+        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
@@ -51,11 +51,12 @@ android {
 repositories {
     jcenter()
     maven { url "https://maven.fabric.io/repo" }
+    maven { url 'https://maven.fabric.io/public' }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile('com.twitter.sdk.android:twitter:1.0.0@aar') {
+    compile('com.twitter.sdk.android:twitter:1.1.1@aar') {
         transitive = true
     }
     compile('com.mopub.sdk.android:mopub:3.1.0@aar') {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
             buildConfigField "String", "CONSUMER_KEY", "\"${props.getProperty("twitterConsumerKey")}\""
             buildConfigField "String", "CONSUMER_SECRET", "\"${props.getProperty("twitterConsumerSecret")}\""
             buildConfigField "String", "MOPUB_AD_UNIT_ID", "\"${props.getProperty("mopubAdUnitId")}\""
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/src/main/java/io/fabric/samples/cannonball/activity/LoginActivity.java
+++ b/app/src/main/java/io/fabric/samples/cannonball/activity/LoginActivity.java
@@ -76,6 +76,7 @@ public class LoginActivity extends Activity {
 
     private void setUpDigitsButton() {
         phoneButton = (DigitsAuthButton) findViewById(R.id.phone_button);
+        phoneButton.setAuthTheme(R.style.AppTheme);
         phoneButton.setCallback(new AuthCallback() {
             @Override
             public void success(DigitsSession digitsSession, String phoneNumber) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,8 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@color/background_beige</item>
+        <item name="dgts__accentColor">@color/green</item>
+        <item name="android:textColorPrimary">@color/green</item>
     </style>
 
     <style name="AboutTheme" parent="android:style/Theme.NoTitleBar.Fullscreen">

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.+'
+        classpath 'com.android.tools.build:gradle:1.0.0-rc4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 17 12:54:49 PDT 2014
+#Tue Dec 23 21:39:09 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
#5 
This PR updates Twitter kit to the version 1.1.0 and adds the green accent color to the theme that Digits uses to tint the buttons.
More information about [Digits Theming](https://dev.twitter.com/twitter-kit/android/digits-theming)